### PR TITLE
re-design output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 check_happo
 vendor/
 .wercker/
+coverage.out

--- a/comm/server2agent.go
+++ b/comm/server2agent.go
@@ -58,8 +58,17 @@ func GetProxyJSON(proxyHosts []string, host string, port int, requestType string
 	return jsonData, agentHost, agentPort, nil
 }
 
-// PostToAgent do HTTPS request and returns HTTP response body, HTTP response status code, communication error, internal error
-func PostToAgent(host string, port int, method string, jsonData []byte) (string, int, error, error) {
+// InternalRuntimeError is check_happo internal runtime error
+type InternalRuntimeError struct {
+	OriginalError error
+}
+
+func (e InternalRuntimeError) Error() string {
+	return e.OriginalError.Error()
+}
+
+// PostToAgent do HTTPS request and returns HTTP response body, HTTP response status code, error
+func PostToAgent(host string, port int, method string, jsonData []byte) (string, int, error) {
 	uri := fmt.Sprintf("https://%s:%d/%s", host, port, method)
 	log := util.Logger()
 	log.Debug("Request: ", uri)
@@ -71,21 +80,21 @@ func PostToAgent(host string, port int, method string, jsonData []byte) (string,
 
 	resp, err := _httpClient.Do(req)
 	if err != nil {
-		return "", 0, err, nil
+		return "", 0, err
 	}
 
 	log.Debug("Response struct:\n", util.DumpStruct(resp))
 	body, err := ioutil.ReadAll(resp.Body)
 	defer resp.Body.Close()
 	if err != nil {
-		return "", 0, nil, err
+		return "", 0, &InternalRuntimeError{OriginalError: err}
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return string(body[:]), resp.StatusCode, fmt.Errorf("happo-agent returns %d", resp.StatusCode), nil
+		return string(body[:]), resp.StatusCode, fmt.Errorf("happo-agent returns %d", resp.StatusCode)
 	}
 
-	return string(body[:]), resp.StatusCode, nil, nil
+	return string(body[:]), resp.StatusCode, nil
 }
 
 // SetHTTPClientTimeout set timeout of httpClient

--- a/comm/server2agent.go
+++ b/comm/server2agent.go
@@ -58,8 +58,8 @@ func GetProxyJSON(proxyHosts []string, host string, port int, requestType string
 	return jsonData, agentHost, agentPort, nil
 }
 
-// PostToAgent do HTTPS request and returns result
-func PostToAgent(host string, port int, method string, jsonData []byte) (string, error) {
+// PostToAgent do HTTPS request and returns HTTP response body, HTTP response status code, communication error, internal error
+func PostToAgent(host string, port int, method string, jsonData []byte) (string, int, error, error) {
 	uri := fmt.Sprintf("https://%s:%d/%s", host, port, method)
 	log := util.Logger()
 	log.Debug("Request: ", uri)
@@ -71,20 +71,21 @@ func PostToAgent(host string, port int, method string, jsonData []byte) (string,
 
 	resp, err := _httpClient.Do(req)
 	if err != nil {
-		return "", err
+		return "", 0, err, nil
 	}
 
 	log.Debug("Response struct:\n", util.DumpStruct(resp))
 	body, err := ioutil.ReadAll(resp.Body)
 	defer resp.Body.Close()
 	if err != nil {
-		return "", err
+		return "", 0, nil, err
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return string(body[:]), fmt.Errorf("HTTP status error: %d", resp.StatusCode)
+		return string(body[:]), resp.StatusCode, fmt.Errorf("happo-agent returns %d", resp.StatusCode), nil
 	}
-	return string(body[:]), nil
+
+	return string(body[:]), resp.StatusCode, nil, nil
 }
 
 // SetHTTPClientTimeout set timeout of httpClient

--- a/comm/server2agent_test.go
+++ b/comm/server2agent_test.go
@@ -67,13 +67,13 @@ func TestPostToAgent1(t *testing.T) {
 	host := found[2]
 	port, _ := strconv.Atoi(found[3])
 
-	jsonStr, _, err, _ := PostToAgent(host, port, METHOD, ([]byte(JSON)))
+	jsonStr, _, err := PostToAgent(host, port, METHOD, ([]byte(JSON)))
 	assert.NotNil(t, jsonStr)
 	assert.Nil(t, err)
 }
 
 func TestPostToAgent2(t *testing.T) {
-	jsonStr, _, err, _ := PostToAgent("localhost", 12345, METHOD, ([]byte(JSON)))
+	jsonStr, _, err := PostToAgent("localhost", 12345, METHOD, ([]byte(JSON)))
 	assert.EqualValues(t, "", jsonStr)
 	assert.NotNil(t, err)
 }
@@ -90,7 +90,7 @@ func TestPostToAgent3(t *testing.T) {
 	host := found[2]
 	port, _ := strconv.Atoi(found[3])
 
-	jsonStr, _, err, _ := PostToAgent(host, port, METHOD, ([]byte(JSON)))
+	jsonStr, _, err := PostToAgent(host, port, METHOD, ([]byte(JSON)))
 	assert.EqualValues(t, "{}\n", jsonStr)
 	assert.NotNil(t, err)
 }
@@ -107,7 +107,7 @@ func TestPostToAgent4(t *testing.T) {
 	host := found[2]
 	port, _ := strconv.Atoi(found[3])
 
-	jsonStr, _, err, _ := PostToAgent(host, port, METHOD, ([]byte(JSON)))
+	jsonStr, _, err := PostToAgent(host, port, METHOD, ([]byte(JSON)))
 	assert.EqualValues(t, "{}\n", jsonStr)
 	assert.NotNil(t, err)
 }

--- a/comm/server2agent_test.go
+++ b/comm/server2agent_test.go
@@ -67,13 +67,13 @@ func TestPostToAgent1(t *testing.T) {
 	host := found[2]
 	port, _ := strconv.Atoi(found[3])
 
-	jsonStr, err := PostToAgent(host, port, METHOD, ([]byte(JSON)))
+	jsonStr, _, err, _ := PostToAgent(host, port, METHOD, ([]byte(JSON)))
 	assert.NotNil(t, jsonStr)
 	assert.Nil(t, err)
 }
 
 func TestPostToAgent2(t *testing.T) {
-	jsonStr, err := PostToAgent("localhost", 12345, METHOD, ([]byte(JSON)))
+	jsonStr, _, err, _ := PostToAgent("localhost", 12345, METHOD, ([]byte(JSON)))
 	assert.EqualValues(t, "", jsonStr)
 	assert.NotNil(t, err)
 }
@@ -90,7 +90,24 @@ func TestPostToAgent3(t *testing.T) {
 	host := found[2]
 	port, _ := strconv.Atoi(found[3])
 
-	jsonStr, err := PostToAgent(host, port, METHOD, ([]byte(JSON)))
+	jsonStr, _, err, _ := PostToAgent(host, port, METHOD, ([]byte(JSON)))
+	assert.EqualValues(t, "{}\n", jsonStr)
+	assert.NotNil(t, err)
+}
+
+func TestPostToAgent4(t *testing.T) {
+	ts := httptest.NewTLSServer(
+		http.HandlerFunc(
+			func(w http.ResponseWriter, r *http.Request) {
+				http.Error(w, "{}", http.StatusInternalServerError)
+			}))
+	defer ts.Close()
+	re, _ := regexp.Compile("([a-z]+)://([A-Za-z0-9.]+):([0-9]+)(.*)")
+	found := re.FindStringSubmatch(ts.URL)
+	host := found[2]
+	port, _ := strconv.Atoi(found[3])
+
+	jsonStr, _, err, _ := PostToAgent(host, port, METHOD, ([]byte(JSON)))
 	assert.EqualValues(t, "{}\n", jsonStr)
 	assert.NotNil(t, err)
 }

--- a/command/monitor.go
+++ b/command/monitor.go
@@ -3,7 +3,7 @@ package command
 import (
 	"encoding/json"
 	"fmt"
-	"log"
+	"net/http"
 	"os"
 
 	"github.com/codegangsta/cli"
@@ -12,57 +12,84 @@ import (
 	"github.com/heartbeatsjp/happo-agent/halib"
 )
 
+const (
+	localErrorMessageFormat    = "ERROR(check_happo): %s"
+	localUnknownMessageFormat  = "UNKNOWN(check_happo): %s"
+	remoteErrorMessageFormat   = "ERROR(happo-agent): %s"
+	remoteUnknownMessageFormat = "UNKNOWN(happo-agent): %s"
+)
+
 // CmdMonitor implements `monitor` subcommand
 func CmdMonitor(c *cli.Context) {
+
+	out, code := cmdMonitor(c.Bool("verbose"),
+		c.String("plugin_name"),
+		c.String("plugin_option"),
+		c.StringSlice("proxy"),
+		c.String("host"),
+		c.Int("port"),
+		c.Int("timeout"),
+	)
+	fmt.Print(out)
+	os.Exit(code)
+}
+
+func cmdMonitor(verbose bool, pluginName, pluginOption string, proxy []string, host string, port int, timeout int) (string, int) {
 	var agentHost string
 	var agentPort int
 	var requestType string
 	var monitorJSONStr []byte
 	var jsonStr []byte
-	var timeout int
 
-	if c.Bool("verbose") {
+	if verbose {
 		util.LoggerLevelDebug()
 	}
 
-	monitorJSONStr, err := getMonitorJSON(c.String("plugin_name"), c.String("plugin_option"))
+	monitorJSONStr, err := getMonitorJSON(pluginName, pluginOption)
 	if err != nil {
-		log.Print(err)
-		os.Exit(halib.MonitorUnknown)
+		return fmt.Sprintf(localErrorMessageFormat, err.Error()), halib.MonitorError
 	}
 
-	if len(c.StringSlice("proxy")) >= 1 {
+	if len(proxy) >= 1 {
 		requestType = "proxy"
-		jsonStr, agentHost, agentPort, err = comm.GetProxyJSON(c.StringSlice("proxy"), c.String("host"), c.Int("port"), "monitor", monitorJSONStr)
+		jsonStr, agentHost, agentPort, err = comm.GetProxyJSON(proxy, host, port, "monitor", monitorJSONStr)
 		if err != nil {
-			log.Print(err)
-			os.Exit(halib.MonitorUnknown)
+			return fmt.Sprintf(localErrorMessageFormat, err.Error()), halib.MonitorError
 		}
 	} else {
 		requestType = "monitor"
-		agentHost = c.String("host")
-		agentPort = c.Int("port")
+		agentHost = host
+		agentPort = port
 		jsonStr = monitorJSONStr
 	}
 
-	timeout = c.Int("timeout")
 	if timeout > 0 {
 		comm.SetHTTPClientTimeout(timeout)
 	}
 
-	res, err := comm.PostToAgent(agentHost, agentPort, requestType, jsonStr)
-	if err != nil {
-		log.Print(err)
-		os.Exit(halib.MonitorError)
+	responseBody, responseStatusCode, communicationError, internalError := comm.PostToAgent(agentHost, agentPort, requestType, jsonStr)
+
+	if internalError != nil {
+		return fmt.Sprintf(localErrorMessageFormat, internalError.Error()), halib.MonitorError
 	}
-	monitorResult, err := parseMonitorJSON(res)
+	if communicationError != nil {
+		// connection failed or responseStatusCode != 200
+		if responseStatusCode == http.StatusGatewayTimeout {
+			return fmt.Sprintf(remoteUnknownMessageFormat, communicationError.Error()), halib.MonitorUnknown
+		}
+		msg := fmt.Sprintf("%s %s", communicationError.Error(), responseBody)
+		return fmt.Sprintf(remoteErrorMessageFormat, msg), halib.MonitorError
+	}
+	monitorResult, err := parseMonitorJSON(responseBody)
 	if err != nil {
-		log.Print(err)
-		os.Exit(halib.MonitorError)
+		return fmt.Sprintf(localErrorMessageFormat, err.Error()), halib.MonitorError
 	}
 
-	fmt.Print(monitorResult.Message)
-	os.Exit(monitorResult.ReturnValue)
+	if responseStatusCode == http.StatusOK {
+		return monitorResult.Message, monitorResult.ReturnValue
+	} else {
+		return fmt.Sprintf(remoteErrorMessageFormat, monitorResult.Message), halib.MonitorError
+	}
 }
 
 func getMonitorJSON(pluginName string, pluginOption string) ([]byte, error) {

--- a/command/monitor_test.go
+++ b/command/monitor_test.go
@@ -1,6 +1,11 @@
 package command
 
 import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"strconv"
 	"testing"
 
 	"github.com/heartbeatsjp/happo-agent/halib"
@@ -24,4 +29,141 @@ func TestParseMonitorJSON1(t *testing.T) {
 	ret, err := parseMonitorJSON(ResponseJSONStr)
 	assert.EqualValues(t, ResponseData, ret)
 	assert.Nil(t, err)
+}
+
+func TestCmdMonitorDirect(t *testing.T) {
+	patterns := []struct {
+		responseBody string
+		responseCode int
+		expectOut    string
+		expectExit   int
+	}{
+		{responseBody: `{"return_value":0,"message":"PROCS OK: 100 processes\n"}`,
+			responseCode: http.StatusOK,
+			expectOut:    "PROCS OK: 100 processes\n",
+			expectExit:   halib.MonitorOK},
+		{responseBody: `{"return_value":1,"message":"PROCS WARNING: 168 processes\n"}`,
+			responseCode: http.StatusOK,
+			expectOut:    "PROCS WARNING: 168 processes\n",
+			expectExit:   halib.MonitorWarning},
+		{responseBody: `{"return_value":2,"message":"PROCS CRITICAL: 170 processes\n"}`,
+			responseCode: http.StatusOK,
+			expectOut:    "PROCS CRITICAL: 170 processes\n",
+			expectExit:   halib.MonitorError},
+		{responseBody: `{"return_value":3,"message":"UNKNOWN ERROR OCCURED\n"}`,
+			responseCode: http.StatusOK,
+			expectOut:    "UNKNOWN ERROR OCCURED\n",
+			expectExit:   halib.MonitorUnknown},
+		{responseBody: ``,
+			responseCode: http.StatusBadRequest,
+			expectOut: `ERROR(happo-agent): happo-agent returns 400 
+`,
+			expectExit: halib.MonitorError},
+		{responseBody: `{"return_value":124,"message":""}`,
+			responseCode: http.StatusInternalServerError,
+			expectOut: `ERROR(happo-agent): happo-agent returns 500 {"return_value":124,"message":""}
+`,
+			expectExit: halib.MonitorError},
+		{responseBody: `{"return_value":124,"message":""}`,
+			responseCode: http.StatusServiceUnavailable,
+			expectOut: `ERROR(happo-agent): happo-agent returns 503 {"return_value":124,"message":""}
+`,
+			expectExit: halib.MonitorError},
+		{responseBody: ``,
+			responseCode: http.StatusGatewayTimeout,
+			expectOut:    "UNKNOWN(happo-agent): happo-agent returns 504",
+			expectExit:   halib.MonitorUnknown},
+	}
+	for _, pattern := range patterns {
+		out, code := testCmdMonitorDirect(pattern.responseBody, pattern.responseCode)
+		assert.Equal(t, pattern.expectOut, out)
+		assert.Equal(t, pattern.expectExit, code)
+	}
+}
+
+func testCmdMonitorDirect(responseBody string, responseCode int) (string, int) {
+
+	ts := httptest.NewTLSServer(
+		http.HandlerFunc(
+			func(w http.ResponseWriter, r *http.Request) {
+				http.Error(w, responseBody, responseCode)
+			}))
+	defer ts.Close()
+	re, _ := regexp.Compile("([a-z]+)://([A-Za-z0-9.]+):([0-9]+)(.*)")
+	found := re.FindStringSubmatch(ts.URL)
+	host := found[2]
+	port, _ := strconv.Atoi(found[3])
+
+	out, code := cmdMonitor(false, "", "", make([]string, 0), host, port, 3)
+
+	return out, code
+}
+
+func TestCmdMonitorProxy(t *testing.T) {
+	patterns := []struct {
+		responseBody string
+		responseCode int
+		expectOut    string
+		expectExit   int
+	}{
+		{responseBody: `{"return_value":0,"message":"PROCS OK: 100 processes\n"}`,
+			responseCode: http.StatusOK,
+			expectOut:    "PROCS OK: 100 processes\n",
+			expectExit:   halib.MonitorOK},
+		{responseBody: `{"return_value":1,"message":"PROCS WARNING: 168 processes\n"}`,
+			responseCode: http.StatusOK,
+			expectOut:    "PROCS WARNING: 168 processes\n",
+			expectExit:   halib.MonitorWarning},
+		{responseBody: `{"return_value":2,"message":"PROCS CRITICAL: 170 processes\n"}`,
+			responseCode: http.StatusOK,
+			expectOut:    "PROCS CRITICAL: 170 processes\n",
+			expectExit:   halib.MonitorError},
+		{responseBody: `{"return_value":3,"message":"UNKNOWN ERROR OCCURED\n"}`,
+			responseCode: http.StatusOK,
+			expectOut:    "UNKNOWN ERROR OCCURED\n",
+			expectExit:   halib.MonitorUnknown},
+		{responseBody: ``,
+			responseCode: http.StatusBadRequest,
+			expectOut: `ERROR(happo-agent): happo-agent returns 400 
+`,
+			expectExit: halib.MonitorError},
+		{responseBody: `{"return_value":124,"message":""}`,
+			responseCode: http.StatusInternalServerError,
+			expectOut: `ERROR(happo-agent): happo-agent returns 500 {"return_value":124,"message":""}
+`,
+			expectExit: halib.MonitorError},
+		{responseBody: `{"return_value":124,"message":""}`,
+			responseCode: http.StatusServiceUnavailable,
+			expectOut: `ERROR(happo-agent): happo-agent returns 503 {"return_value":124,"message":""}
+`,
+			expectExit: halib.MonitorError},
+		{responseBody: ``,
+			responseCode: http.StatusGatewayTimeout,
+			expectOut:    "UNKNOWN(happo-agent): happo-agent returns 504",
+			expectExit:   halib.MonitorUnknown},
+	}
+	for _, pattern := range patterns {
+		out, code := testCmdMonitorDirect(pattern.responseBody, pattern.responseCode)
+		assert.Equal(t, pattern.expectOut, out)
+		assert.Equal(t, pattern.expectExit, code)
+	}
+}
+
+func testCmdMonitorProxy(responseBody string, responseCode int) (string, int) {
+
+	ts := httptest.NewTLSServer(
+		http.HandlerFunc(
+			func(w http.ResponseWriter, r *http.Request) {
+				http.Error(w, responseBody, responseCode)
+			}))
+	defer ts.Close()
+	re, _ := regexp.Compile("([a-z]+)://([A-Za-z0-9.]+):([0-9]+)(.*)")
+	found := re.FindStringSubmatch(ts.URL)
+	host := found[2]
+	port, _ := strconv.Atoi(found[3])
+
+	proxy := []string{fmt.Sprintf("%s:%v", host, port)}
+	out, code := cmdMonitor(false, "", "", proxy, host, port, 3)
+
+	return out, code
 }

--- a/contrib/check_happo_test.py
+++ b/contrib/check_happo_test.py
@@ -1,0 +1,116 @@
+# coding: utf-8
+
+"""
+# Usage
+
+```
+python check_happo_test.py | sort -n
+```
+
+- may need about 1 minutes
+- sometime fails. timing problem?
+    - exit status is correct, but message is not same
+
+# Requirements
+
+- python 2.7
+- run on CentOS 7 + happo-agent
+    - happo-agent listen 0.0.0.0
+    - 127.0.1.1 can reach to happo-agent
+- 192.168.0.1 leads to timeout
+"""
+
+import subprocess
+import shlex
+import re
+from multiprocessing import Process
+
+
+def run_test(index, command_line, expect_out, expect_code):
+    p = subprocess.Popen(shlex.split(command_line),
+                         stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    out, err = p.communicate()
+    if isinstance(expect_out, re._pattern_type):
+        if re.search(expect_out, out.strip()) and p.returncode == expect_code:
+            return u"%d OK: %s" % (index, command_line)
+        return u"%d NG: %s\t(expect exit=%d)\t'%s'\t(actual exit=%d)\t'%s'" % (
+            index,
+            command_line,
+            expect_code,
+            expect_out.pattern,
+            p.returncode,
+            out)
+    else:
+        if expect_out == out.strip() and p.returncode == expect_code:
+            return u"%d OK: %s" % (index, command_line)
+        return u"%d NG: %s\t(expect exit=%d)\t'%s'\t(actual exit=%d)\t'%s'" % (
+            index,
+            command_line,
+            expect_code,
+            expect_out,
+            p.returncode,
+            out)
+
+
+def process(*args, **kwargs):
+    print run_test(*args, **kwargs)
+
+
+def main():
+    patterns = [
+        ('monitor -H 127.0.0.1 -p check_procs -o ""',
+         re.compile('PROCS OK: .* processes'), 0),
+        ('monitor -H 127.0.0.1 -p check_procs -o "-w 0"',
+         re.compile('PROCS WARNING: .* processes'), 1),
+        ('monitor -H 127.0.0.1 -p check_procs -o "-c 0"',
+         re.compile('PROCS CRITICAL: .* processes'), 2),
+        ('monitor -H 127.0.0.1 -p check_procs -o "-c 0 -a"',
+         re.compile('Usage:'), 3),
+        ('monitor -H 127.0.0.1 -p notfound -o ""',
+         'stdout=, stderr=/bin/sh: /usr/local/bin/notfound: No such file or directory', 127),
+        ('monitor -X 127.0.0.1 -H 127.0.0.1 -p check_procs -o ""',
+         re.compile('PROCS OK: .* processes'), 0),
+        ('monitor -X 127.0.0.1 -H 127.0.0.1 -p check_procs -o "-w 0"',
+         re.compile('PROCS WARNING: .* processes'), 1),
+        ('monitor -X 127.0.0.1 -H 127.0.0.1 -p check_procs -o "-c 0"',
+         re.compile('PROCS CRITICAL: .* processes'), 2),
+        ('monitor -X 127.0.0.1 -H 127.0.0.1 -p notfound -o ""',
+         'stdout=, stderr=/bin/sh: /usr/local/bin/notfound: No such file or directory', 127),
+        ('monitor -H 127.0.1.1 -p check_procs -o ""',
+         'ERROR(happo-agent): happo-agent returns 403 Access Denied', 2),
+        ('monitor -X 127.0.0.1 -H 127.0.1.1 -p check_procs -o ""',
+         'ERROR(happo-agent): happo-agent returns 403 Access Denied', 2),
+        ('monitor -X 127.0.1.1 -H 127.0.0.1 -p check_procs -o ""',
+         'ERROR(happo-agent): happo-agent returns 403 Access Denied', 2),
+        ('monitor -H 192.168.0.1 -p check_procs -o ""',
+         'ERROR(happo-agent): Post https://192.168.0.1:6777/monitor: net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)', 2),
+        ('monitor -X 127.0.0.1 -H 192.168.0.1 -p check_procs -o ""',
+         'ERROR(happo-agent): Post https://127.0.0.1:6777/proxy: net/http: request canceled (Client.Timeout exceeded while awaiting headers)', 2),
+        ('monitor -X 192.168.0.1 -H 127.0.0.1 -p check_procs -o ""',
+         'ERROR(happo-agent): Post https://192.168.0.1:6777/proxy: net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)', 2),
+        ('monitor -H 192.168.0.1 -p check_procs -o "" -t 1',
+         'ERROR(happo-agent): Post https://192.168.0.1:6777/monitor: net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)', 2),
+        ('monitor -X 127.0.0.1 -H 192.168.0.1 -p check_procs -o "" -t 1',
+         'ERROR(happo-agent): Post https://127.0.0.1:6777/proxy: net/http: request canceled (Client.Timeout exceeded while awaiting headers)', 2),
+        ('monitor -X 192.168.0.1 -H 127.0.0.1 -p check_procs -o "" -t 1',
+         'ERROR(happo-agent): Post https://192.168.0.1:6777/proxy: net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)', 2),
+        ('monitor -H 192.168.0.1 -p check_procs -o "" -t 300',
+         re.compile('ERROR\(happo-agent\): Post https://192.168.0.1:6777/monitor: dial tcp 192.168.0.1:6777: getsockopt:.*'), 2),
+        ('monitor -X 127.0.0.1 -H 192.168.0.1 -p check_procs -o "" -t 300',
+         'UNKNOWN(happo-agent): happo-agent returns 504', 3),
+        ('monitor -X 192.168.0.1 -H 127.0.0.1 -p check_procs -o "" -t 300',
+         re.compile('ERROR\(happo-agent\): Post https://192.168.0.1:6777/proxy: dial tcp 192.168.0.1:6777: getsockopt:.*'), 2),
+    ]
+
+    processes = []
+    for index, pattern in enumerate(patterns):
+        processes.append(Process(target=process, args=(
+            index + 1, "./check_happo monitor %s" % (pattern[0]), pattern[1], pattern[2])))
+    for p in processes:
+        p.start()
+    for p in processes:
+        p.join()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
In case some error has occured, add prefix to stdout.

Raw golang `err.Error()` is confusing.